### PR TITLE
Delete Booking, Assign Meeting Owner

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -120,15 +120,21 @@ database_read_servicer = database_reading.DatabaseReadingServices(
 databaseConn = database_connection.DatabaseConnection()
 database_reader = database_reading.DatabaseReadingServices(databaseConn)
 
-test2 = database_writing.DatabaseWritingServices(
+createUser = database_writing.DatabaseWritingServices(
     databaseConn, database_reader
-).create_new_booking("2026-11-11", "10:30:00", "03:00:00", "1000", "1G11", 15)
+).delete_booking(1046)
 
-test = database_reading.DatabaseReadingServices(
-    database_connection.DatabaseConnection()
-).get_username_via_RUID("1000")
+# testAddBID = testAddBID[1]
+# if testAddBID == 0:
+#     test2 = database_writing.DatabaseWritingServices(
+#         databaseConn, database_reader
+#     ).associate_unregistered_user_with_booking(testAddBID, 1000)
 
-print("Checking For insertion... ", test2)
+# test = database_reading.DatabaseReadingServices(
+#     database_connection.DatabaseConnection()
+# ).get_username_via_RUID("1000")
+
+print("Checking For create user... ", createUser)
 
 # -- ROUTES --
 from account.routes import account_bp

--- a/app/database_connection.py
+++ b/app/database_connection.py
@@ -22,7 +22,8 @@ class DatabaseConnection:
                     user=self.user,
                     password=self.password,
                     database=self.database,
-                    ssl_disabled=True,
+                    ssl_verify_cert=False,  # fine for now
+                    ssl_disabled=False,
                 )
                 print("OOOOOOO WE ARE CONNECTED BABY!!!!")
                 return test

--- a/app/database_reading.py
+++ b/app/database_reading.py
@@ -200,7 +200,7 @@ class DatabaseReadingServices:
             "SELECT BID FROM Room WHERE roomNumber = %s", (room_number,)
         )
 
-        result = self.cursor.fetchall()[0][0]
+        result = self.cursor.fetchone()[0]
 
         if result:
             return False

--- a/app/database_writing.py
+++ b/app/database_writing.py
@@ -16,7 +16,6 @@ class DatabaseWritingServices:
         first_name: str,
         last_name: str,
         password: str,
-        BID="",
     ):
         """Generic function for adding a user to the Database \n
         NOTE: CHECKS FOR EXISTING USERS, NEEDS EMAIL VALIDATION(?) \n
@@ -28,22 +27,21 @@ class DatabaseWritingServices:
         )
 
         if not checkExists:
-            if BID:
-                print("inserting with BID")
-                query = """
-                    INSERT INTO RegisteredUser
-                    (BID, username, email, pass, firstName, lastName)
-                    VALUES ( %s, %s, %s, %s, %s, %s)
-                """
-                values = (BID, username, email, password, first_name, last_name)
 
-            else:
-                query = """
-                    INSERT INTO RegisteredUser
-                    (username, email, pass, firstName, lastName)
-                    VALUES ( %s, %s, %s, %s, %s)
-                """
-                values = (username, email, password, first_name, last_name)
+            query = """
+                INSERT INTO RegisteredUser
+                (username, email, pass, firstName, lastName)
+                VALUES (%s, %s, %s, %s, %s)
+            """
+            values = (username, email, password, first_name, last_name)
+
+            # else:
+            #     query = """
+            #         INSERT INTO RegisteredUser
+            #         (username, email, pass, firstName, lastName)
+            #         VALUES ( %s, %s, %s, %s, %s)
+            #     """
+            #     values = (username, email, password, first_name, last_name)
 
             self.cursor.execute(query, values)
             self.conn.commit()
@@ -62,7 +60,7 @@ class DatabaseWritingServices:
     ):
         """Generic function for adding a booking to the Database \n
         NOTE: CHECKS FOR EXISTING BOOKED ROOMS AND ROOM CAPACITY \n
-        TRUE == BOOKING ADDED \n
+        TRUE == BOOKING ADDED, AND RETURNS GENERATED BID \n
         FALSE == BOOKING DETAILS FAILED; ROOM TAKEN OR MEETING SIZE TOO LARGE"""
 
         checkAvailable = self.reader.check_for_room_availability(
@@ -94,10 +92,19 @@ class DatabaseWritingServices:
                     self.cursor.lastrowid
                 )  # POTENTIALLY unsafe for multiple users (?)
 
+                attempt_to_book_room = self.book_a_room_after_booking(
+                    booking_id, meeting_room
+                )
                 attempt_to_associate = self.associate_registered_user_with_booking(
                     booking_id, meeting_owner
                 )
-                return True
+
+                if attempt_to_associate and attempt_to_book_room:
+
+                    self.cursor.close()
+                    return True, (booking_id)
+                else:
+                    return False, "Unable to associate"
 
             else:
                 return (
@@ -106,6 +113,31 @@ class DatabaseWritingServices:
                 )
 
         return False, "Room is NOT Available"
+
+    def book_a_room_after_booking(self, BID: int, meeting_room):
+        """Generic function for assignment of a room to a particular booking \n
+        TRUE == ABLE TO BOOK ROOM \n
+        FALSE == ROOM ALREADY BOOKED"""
+
+        try:
+            query = """
+                UPDATE Room
+                SET BID = (%s)
+                WHERE roomNumber = (%s)
+                AND BID IS NULL
+            """
+
+            values = (BID, meeting_room)
+
+            self.cursor.execute(query, values)
+            self.conn.commit()
+
+            return True
+
+        except Exception as e:
+            self.conn.rollback()
+            print("INSERT ERROR: ", e)
+            return False, str(e)
 
     def associate_registered_user_with_booking(self, BID: int, RUID: str):
         """Generic function for associating a booking to Registered Users \n
@@ -125,4 +157,84 @@ class DatabaseWritingServices:
 
         self.cursor.execute(query, values)
         self.conn.commit()
+        self.cursor.close()
         return True
+
+    def associate_unregistered_user_with_booking(self, BID: int, URUID: str):
+        """Generic function for associating a booking to Registered Users \n
+        TRUE == ASSOCIATION RECORD ADDED \n
+        FALSE == ASSOCIATION RECORD FAILED"""
+
+        query = """
+            INSERT INTO UnregisteredBookingAttendees
+            (BID, unregisteredAttendee)
+            VALUES ( %s, %s)
+        """
+
+        values = (BID, URUID)
+
+        self.cursor.execute(query, values)
+        self.conn.commit()
+        return True
+
+    def delete_booking(self, BID: int):
+        """Generic function to delete a booking from the Database \n
+        NOTE: REMOVES MEETING OWNER AND ATTENDEES ASSOCIATED WITH BOOKING FROM THE RELATION TABLE \n
+        TRUE == BOOKING DELETED \n
+        FALSE == BOOKING DIDNT EXIST OR OTHER FAILURE"""
+
+        try:
+            attempt_delete_association = self.delete_association(BID=BID)
+            attempt_free_room = self.update_room_as_available(BID=BID)
+
+            if attempt_delete_association and attempt_free_room:
+                self.cursor.execute("DELETE FROM Booking WHERE BID = %s", (BID,))
+                self.conn.commit()
+
+                return True
+
+        except Exception as e:
+            self.conn.rollback()
+            print("DELETE ERROR: ", e)
+            return False, str(e)
+
+    def delete_association(self, BID: int):
+        """Generic function to remove an association between a Booking and an Attendee \n
+        NOTE: ASSOCIATION BETWEEN BOOKING AND ALL RELATED ATTENDEES MUST BE DELETED BEFORE A BOOKING IS DELETED
+        TRUE == ASSOCIATION DELETED \n
+        FALSE == ASSOCIATION DELETION ERROR + ERROR MSG"""
+
+        try:
+            self.cursor.execute(
+                "DELETE FROM RegisteredBookingAttendees WHERE BID = %s", (BID,)
+            )
+            self.conn.commit()
+
+            self.cursor.execute(
+                "DELETE FROM UnregisteredBookingAttendees WHERE BID = %s", (BID,)
+            )
+
+            self.conn.commit()
+            return True
+
+        except Exception as e:
+            self.conn.rollback()
+            print("DELETE ERROR: ", e)
+            return False, str(e)
+
+    def update_room_as_available(self, BID: int):
+        """Generic function to update the database that a room is now available when deleting a booking \n
+        NOTE: CALLED WHEN DELETING A BOOKING \n
+        TRUE == ROOM UPDATED AS AVAILABLE \n
+        FALSE == ROOM NOT UPDATED"""
+
+        try:
+            self.cursor.execute("UPDATE Room SET BID = NULL WHERE BID = %s", (BID,))
+            self.conn.commit()
+
+            return True
+
+        except Exception as e:
+            self.conn.rollback()
+            print("UPDATE ERROR: ", e)
+            return False, str(e)


### PR DESCRIPTION
This commit handles most (if not, ALL) booking deletion logic. This includes removing associations and freeing booking rooms.

This commit also includes logic to create a booking, but you need the pertinent information (everything except numberOfConfirmations, reminderSent, sharableLink, and BID).

WHEN A BOOKING IS CREATED:
- The "RegisteredBookingAttendees" will be updated with the generated BID and the respective RUID/meetingOwner

- The Room's "BID" column will be filled with the respective BID generated, indicating that the room is busy/unbookable. This logic might need some tweaking to specify times, or may need an associated table.